### PR TITLE
Ignore tombstones

### DIFF
--- a/keychain.cpp
+++ b/keychain.cpp
@@ -400,12 +400,14 @@ void Keychain::reloadItems() {
     }
 
     for (const auto& contents_item : contents_json) {
-        try {
-            loadItem(contents_item[0]);
-        } catch (std::exception& e) {
-            std::stringstream ss;
-            ss << "Error loading item " << contents_item[2] << ": " << e.what();
-            errorDialog(ss.str());
+        if(contents_item[1] != "system.Tombstone") {
+            try {
+                loadItem(contents_item[0]);
+            } catch (std::exception& e) {
+                std::stringstream ss;
+                ss << "Error loading item " << contents_item[2] << ": " << e.what();
+                errorDialog(ss.str());
+            }
         }
     }
 


### PR DESCRIPTION
When items are deleted in the official 1Password app, they are not removed from contents.js. Gonepass would try to open deleted items and raise an error since the `<item_id>.1password` datafile is gone. This change skips loading items that are marked as a `system.Tombstone` type in contents.js.