### PR TITLE
Focus on password field by default

### DIFF
--- a/lock_screen.h
+++ b/lock_screen.h
@@ -42,6 +42,7 @@ public:
         password_field.signal_activate().connect([this]() { unlock_button.clicked(); });
 
         show_all_children();
+        password_field.grab_focus();
     };
 
     std::string getPassword() {


### PR DESCRIPTION
Saves you a click/tab on launch and mimics behavior of the Mac app.